### PR TITLE
Set mariadb's pid-dir to mysql's datadir

### DIFF
--- a/playbooks/group_vars/cloudhost.yml
+++ b/playbooks/group_vars/cloudhost.yml
@@ -3,6 +3,7 @@
 ## Base Vars
 nexcess_repo_enabled: false
 server_selinux_enforcing: false
+mysql_pid_file: /var/lib/mysql/mysqld.pid
 
 ## IWorx Vars
 iw_ns1: "ns1.nexcess.net"


### PR DESCRIPTION
The rationale behind the change is /run owned by root:root/0755 on el7
so the mysql user can't create /var/run/mysql (/var/run is an symlink to /run)
when mariadb is restarted (or started for the first time after a reboot) leaving
mariadb in an failed state.
This isn't an problem during the initial provisioning since ansible creates the parent directory.

The change should be merged after https://github.com/nexcess/ansible-role-mariadb/pull/10
so /var/lib/mysql is created by the package like normal.