### PR TITLE
prevent puppet from running in non-blocking mode

### DIFF
--- a/playbooks/group_vars/cloudhost.yml
+++ b/playbooks/group_vars/cloudhost.yml
@@ -26,3 +26,6 @@ firewall_v4_group_rules:
 firewall_v6_group_rules:
   401 allow iworx to the world:
     - "-A INPUT -p tcp --dport 2443 -j ACCEPT"
+
+## Prevent puppet from running in a non-blocking fashion
+puppet_agent_fire_and_forget: false


### PR DESCRIPTION
Ansible doesn't appear to be setting any of the values within the ~iworx/etc/domain-blacklist.txt file (although this file is provided by the interworx RPM). From what I can tell, puppet is the only thing that is setting this. Since puppet is running in async (non-blocking) mode, I believe that it's adding the hostname to the domain-blacklist.txt file *prior* to the [iworx-ssl-services](https://github.com/nexcess/ansible-playbook-cloudhost/blob/master/playbooks/tasks/iworx-ssl-services.yml) playbook run.