### PR TITLE
[NSO-1428] leave ftp port at 21

### DIFF
--- a/playbooks/tasks/iworx-settings.yml
+++ b/playbooks/tasks/iworx-settings.yml
@@ -15,9 +15,9 @@
     --stats.webalizer_enabled=0
     --rrd_ping_host=nexcess.net
 
-- name: Set FTP to Port 990
-  command: >
-    sed -i 's/^Port.*21$/Port  990/g' /etc/proftpd.conf
+# - name: Set FTP to Port 990
+#   command: >
+#     sed -i 's/^Port.*21$/Port  990/g' /etc/proftpd.conf
 
 #- name: Set FTP InterWorx Settings
 #  command: >


### PR DESCRIPTION
Puppet will ensure that TLS is required in the config