### PR TITLE
[NSO-1482] Implement proper nexkit install

### DIFF
--- a/playbooks/base.yml
+++ b/playbooks/base.yml
@@ -19,5 +19,6 @@
     - include: tasks/all.yml mode="pre"
   roles:
     - nexcess.server
+    - nexcess.repo
   post_tasks:
     - include: tasks/all.yml mode="post"

--- a/playbooks/tasks/all.yml
+++ b/playbooks/tasks/all.yml
@@ -26,3 +26,11 @@
   set_fact: {"{{ item }}_frontnet_addrs":"{{ groups[item] | map('extract', hostvars, ['frontnet_addr']) | list }}"}
   with_items: "{{ groups }}"
   run_once: true
+
+# this task is placed here instead of cloudhost.yml so that CI tests pass
+- name: Install nexkit
+  yum:
+    name="nexkit"
+    enablerepo="nexcess"
+    state="present"
+  when: mode == "post"

--- a/playbooks/tasks/cloudhost.yml
+++ b/playbooks/tasks/cloudhost.yml
@@ -35,3 +35,10 @@
     enablerepo="remi"
     state="present"
   when: mode == 'post'
+
+- name: Install nexkit
+  yum:
+    name="nexkit"
+    enablerepo="nexcess"
+    state="present"
+  when: mode == "post"

--- a/playbooks/tasks/cloudhost.yml
+++ b/playbooks/tasks/cloudhost.yml
@@ -35,10 +35,3 @@
     enablerepo="remi"
     state="present"
   when: mode == 'post'
-
-- name: Install nexkit
-  yum:
-    name="nexkit"
-    enablerepo="nexcess"
-    state="present"
-  when: mode == "post"

--- a/requirements.yml
+++ b/requirements.yml
@@ -10,3 +10,5 @@
   name: "nexcess.php"
 - src: "git+https://github.com/nexcess/ansible-role-mariadb.git"
   name: "nexcess.mariadb"
+- src: "git+https://github.com/nexcess/ansible-role-repo-nexcess.git"
+  name: "nexcess.repo"


### PR DESCRIPTION
Uses the existing nexcess repo role to allow us to install nexkit before puppet does it, so it can be used for app installs later