### PR TITLE
Change fresh install iworx release channel to release-candidate

### DIFF
--- a/spec/vars.yml
+++ b/spec/vars.yml
@@ -1,5 +1,5 @@
 ---
-iw_release_channel: 'beta'
+iw_release_channel: 'release-candidate'
 iw_master_email: 'citests@nexcess.net'
 iw_master_password: 'nexcesscitests'
 iw_license_key: 'NEXCESS_CI_LICENSE'


### PR DESCRIPTION
We need to start using the beta channel for iworx 6.2 (php72) testing.