### PR TITLE
switch to iworx stable channel

### DIFF
--- a/playbooks/group_vars/cloudhost.yml
+++ b/playbooks/group_vars/cloudhost.yml
@@ -24,7 +24,7 @@ iw_ssl_email: "ssladmin@nexcess.net"
 iw_symlink_base_php: true
 iw_symlink_base_php_path: "/opt/remi/php56/root/usr/bin/php"
 
-iw_release_channel: 'release'
+iw_release_channel: 'stable'
 
 ## PHP
 php_single_version: false

--- a/playbooks/tasks/iworx-packages.yml
+++ b/playbooks/tasks/iworx-packages.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Convert Puppet IntetrWorx Packages To InterWorx Format
+- name: Convert Puppet InterWorx Packages To InterWorx Format
   set_fact: { iw_packages: "{{ iw_packages | default([]) + [item.value] }}"}
   with_dict: "{{ hostvars[inventory_hostname]['interworx::metaworx::packages'] }}"
 

--- a/spec/test.sh
+++ b/spec/test.sh
@@ -41,7 +41,7 @@ printf ${green}"Installing Ruby and Bundler."${neutral}
 docker exec --tty $container_id env TERM=xterm bash -c 'yum install -y centos-release-scl'
 docker exec --tty $container_id env TERM=xterm bash -c 'yum-config-manager --enable rhel-server-rhscl-7-rpms'
 docker exec --tty $container_id env TERM=xterm bash -c 'yum install -y rh-ruby22'
-docker exec --tty $container_id env TERM=xterm bash -c 'source /opt/rh/rh-ruby22/enable; gem install bundler'
+docker exec --tty $container_id env TERM=xterm bash -c 'source /opt/rh/rh-ruby22/enable; gem install bundler -v "1.17.3"'
 
 # Install Gems and Run Serverspec
 printf ${green}"Installing deps and running tests."${neutral}


### PR DESCRIPTION
this is because iworx is going to promote 6.3 to release soon, we need
to stay on 6.1 until we are ready to upgrade


```
[1533][root@cloudhost-66036 corlando]$ repoquery interworx --disablerepo=\* --enablerepo=interworx-stable
interworx-0:6.1.26-1626.iworx.noarch
[1533][root@cloudhost-66036 corlando]$ repoquery interworx --disablerepo=\* --enablerepo=interworx-release
interworx-0:6.1.26-1626.iworx.noarch
[1533][root@cloudhost-66036 corlando]$ repoquery interworx --disablerepo=\* --enablerepo=interworx-beta
interworx-0:6.3.8-1660.iworx.noarch
```

current versions in each channel ^^