### PR TITLE
make SITEWORX_SSH_FEATURE caps

### DIFF
--- a/playbooks/tasks/iworx-multi-ssh.yml
+++ b/playbooks/tasks/iworx-multi-ssh.yml
@@ -9,5 +9,5 @@
     /home/interworx/bin/config.pex
     --global
     --set
-    --name siteworx_ssh_feature
+    --name SITEWORX_SSH_FEATURE
     --value on

--- a/spec/default/cloudhost_iworx_spec.rb
+++ b/spec/default/cloudhost_iworx_spec.rb
@@ -17,7 +17,7 @@ describe package('libnss-mysql') do
   it { should be_installed }
 end
 
-describe command('/home/interworx/bin/config.pex --global --get --name siteworx_ssh_feature') do
+describe command('/home/interworx/bin/config.pex --global --get --name SITEWORX_SSH_FEATURE') do
   its(:stdout) { should match /on/ }
 end
 


### PR DESCRIPTION
Tim College [3:34 PM]
Next thing - can you start setting/reading `SITEWORX_SSH_FEATURE` instead of `siteworx_ssh_feature`? We’re normalizing our internal config names to be all caps, and will be making all customer config names lowercase.  Yours already match that pattern, with this one exception, as far as Paul could tell.

Current code is case-insensitive, so it won’t break anything, but at some near-future point, that will change

Chris Orlando [3:35 PM]
so do we need to fix the old ones

Tim College [3:35 PM]
No - our upgrade code will adapt them.
But once it’s case-sensitive, you’d be setting something irrelevant