### PR TITLE
fix setting available php versions

### DIFF
--- a/playbooks/tasks/iworx-php-scl.yml
+++ b/playbooks/tasks/iworx-php-scl.yml
@@ -9,7 +9,7 @@
 
 - name: Find Installed PHP Versions
   shell: >
-    ls -dm "{{ php_remi_root }}"/* | tr -d ' '
+    find "{{ php_remi_root }}" -maxdepth 1 -name 'php*' -printf '%p,' | sed 's/.$//'
   register: directory_php_names
 
 - name: Enable Installed PHP Versions


### PR DESCRIPTION
for some reason, the ls output can give a newline

```
$ ls -dm "/opt/remi"/* | tr -d ' '
/opt/remi/php56/,/opt/remi/php70/,/opt/remi/php71/,/opt/remi/php72/,
/opt/remi/php73/
```

at first glance, it looks like tr is adding it:
```
$ ls -dm "/opt/remi"/*
/opt/remi/php56/, /opt/remi/php70/, /opt/remi/php71/, /opt/remi/php72/, /opt/remi/php73/
```

however there is actually a newline character in the ls output:
```
$ ls -dm "/opt/remi"/* | xxd
0000000: 2f6f 7074 2f72 656d 692f 7068 7035 362f  /opt/remi/php56/
0000010: 2c20 2f6f 7074 2f72 656d 692f 7068 7037  , /opt/remi/php7
0000020: 302f 2c20 2f6f 7074 2f72 656d 692f 7068  0/, /opt/remi/ph
0000030: 7037 312f 2c20 2f6f 7074 2f72 656d 692f  p71/, /opt/remi/
0000040: 7068 7037 322f 2c0a 2f6f 7074 2f72 656d  php72/,./opt/rem
0000050: 692f 7068 7037 332f 0a                   i/php73/.
```

the 8th byte of line 4 is 0x0a when it should be 0x20

using find avoids this entirely:
```
$ find "/opt/remi" -maxdepth 1 -name 'php*' -printf '%p,' | sed 's/.$//'
/opt/remi/php56,/opt/remi/php70,/opt/remi/php71,/opt/remi/php72,/opt/remi/php73
```

and hexdump
```
$ find "/opt/remi" -maxdepth 1 -name 'php*' -printf '%p,' | sed 's/.$//' | xxd
0000000: 2f6f 7074 2f72 656d 692f 7068 7035 362c  /opt/remi/php56,
0000010: 2f6f 7074 2f72 656d 692f 7068 7037 302c  /opt/remi/php70,
0000020: 2f6f 7074 2f72 656d 692f 7068 7037 312c  /opt/remi/php71,
0000030: 2f6f 7074 2f72 656d 692f 7068 7037 322c  /opt/remi/php72,
0000040: 2f6f 7074 2f72 656d 692f 7068 7037 33    /opt/remi/php73
```