### PR TITLE
ensure base packages are up to date

### DIFF
--- a/playbooks/tasks/cloudhost.yml
+++ b/playbooks/tasks/cloudhost.yml
@@ -1,4 +1,11 @@
 ---
+- name: Ensure base packages are up to date
+  yum:
+    name: '*'
+    state: 'latest'
+    disablerepo: '*'
+    enablerepo: 'base,updates'
+  when: mode == 'pre'
 
 - include: iworx-ini.yml
   when:


### PR DESCRIPTION
we've noticed through the normal deploy process that sometimes *some* packages will get updated, but related packages (not necessarily dependencies) don't. this should ensure that the all the the cloudhost starts in a fully updated base state before we start applying our changes and stack to it.