### PR TITLE
[NSE-1705] dont install nexkit on cloudhosts

### DIFF
--- a/playbooks/tasks/cloudhost.yml
+++ b/playbooks/tasks/cloudhost.yml
@@ -44,9 +44,9 @@
   when: mode == 'post'
 
 # this task is placed here instead of cloudhost.yml so that CI tests pass
-- name: Install nexkit
-  yum:
-    name="nexkit"
-    enablerepo="nexcess"
-    state="present"
-  when: mode == "post"
+#- name: Install nexkit
+#  yum:
+#    name="nexkit"
+#    enablerepo="nexcess"
+#    state="present"
+#  when: mode == "post"


### PR DESCRIPTION
tl;dr we don't need it anymore because nxcli does everything anyway + puppet installs nexkit before we consider the cloudhost to be complete. It's broken now because i moved rpms around in the private repos. This doesn't have to be a permanent fix but will get things building again for now.