### PR TITLE
ImageMagick6 -> ImageMagick

### DIFF
--- a/playbooks/tasks/cloudhost.yml
+++ b/playbooks/tasks/cloudhost.yml
@@ -38,7 +38,7 @@
 
 - name: Install ImageMagick
   yum:
-    name="ImageMagick6"
+    name="ImageMagick"
     enablerepo="remi"
     state="present"
   when: mode == 'post'


### PR DESCRIPTION
It's been renamed:

$ rpm -q --changelog ImageMagick | head
* Thu Apr 09 2020 Remi Collet <remi@remirepo.net> - 6.9.11.6-2
- rename to ImageMagick on EL-7

* Tue Apr 07 2020 Remi Collet <remi@remirepo.net> - 6.9.11.6-1
- update to version 6.9.11 patch level 6

* Mon Apr 06 2020 Remi Collet <remi@remirepo.net> - 6.9.11.5-2
- test build for upstream patch for
  https://github.com/ImageMagick/ImageMagick6/issues/80