### PR TITLE
[SOS-2131] reboot cloudhosts as final task

### DIFF
--- a/playbooks/tasks/cloudhost.yml
+++ b/playbooks/tasks/cloudhost.yml
@@ -41,10 +41,10 @@
     name="ImageMagick"
     enablerepo="remi"
     state="present"
-  when: mode == 'post'
+  when: mode == "post"
 
 ## this should always be the last task
 - name: Restart Cloudhost
   reboot:
     test_command="/bin/true"
-  when: mode == 'post'
+  when: mode == "post"

--- a/playbooks/tasks/cloudhost.yml
+++ b/playbooks/tasks/cloudhost.yml
@@ -43,10 +43,8 @@
     state="present"
   when: mode == 'post'
 
-# this task is placed here instead of cloudhost.yml so that CI tests pass
-#- name: Install nexkit
-#  yum:
-#    name="nexkit"
-#    enablerepo="nexcess"
-#    state="present"
-#  when: mode == "post"
+## this should always be the last task
+- name: Restart Cloudhost
+  reboot:
+    test_command="/bin/true"
+  when: mode == 'post'


### PR DESCRIPTION
We do the exact thing for containerhosts already, for similar reasons (to boot on the newer kernel prior to provisioning). The kernel is installed via Puppet, but since Puppet is triggered by Ansible, it should be installed on the server by the time the post task runs.