### PR TITLE
2021-04-07 swap order of mariadb and interworx role

### DIFF
--- a/playbooks/setup.yml
+++ b/playbooks/setup.yml
@@ -14,8 +14,8 @@
     - { role: nexcess.php, php_prefix: "php71" }
     - { role: nexcess.php, php_prefix: "php72" }
     - { role: nexcess.php, php_prefix: "php73" }
-    - nexcess.interworx
     - nexcess.mariadb
+    - nexcess.interworx
     - { role: nexcess.puppet, when: "nex_env_target is undefined or nex_env_target != 'vagrant'" }
     - nexcess.repo
   post_tasks:


### PR DESCRIPTION
Currently mariadb is being installed by goiworx, through interworx role, from the CentOS7 base repository putting us on version 5.5.68-1, once this role completes the mariadb role uninstalls mariadb from base, adds the mariadb repository, and installs mariadb 10.3. However, due to the mysql_upgrade variable being set to false we never run mysql_upgrade. This does not seem to have been a problem until recently when we switched from mariadb 10.2 to mariadb 10.3, we are now seeing errors such as `2021-04-06 15:04:51 159019 [ERROR] Missing system table mysql.roles_mapping; please run mysql_upgrade to create it` due to these improper upgrades. Tested swapping order of the interworx and mariadb role on a nc-large.test host and mariadb was only installed once.