### PR TITLE
fix post run reboot conditional

### DIFF
--- a/playbooks/tasks/cloudhost.yml
+++ b/playbooks/tasks/cloudhost.yml
@@ -47,4 +47,4 @@
 - name: Restart Cloudhost
   reboot:
     test_command="/bin/true"
-  when: mode == "post" and post_run_reboot is true
+  when: mode == "post" and post_run_reboot is defined and post_run_reboot


### PR DESCRIPTION
new builds are failing with

```
The error was: template error while templating string: no test named 'true'. String: {% if mode == \"post\" and post_run_reboot is true %} True {% else %} False {% endif %}\n\nThe error appears to be in '/opt/playbook/playbooks/tasks/cloudhost.yml': line 47, column 3
```