### PR TITLE
set quota mount options on root partition

### DIFF
--- a/playbooks/tasks/cloudhost.yml
+++ b/playbooks/tasks/cloudhost.yml
@@ -43,6 +43,37 @@
     state="present"
   when: mode == "post"
 
+- name: Enable quota in grub cmdline flags
+  lineinfile:
+    path: /etc/default/grub
+    regexp: '^GRUB_CMDLINE_LINUX_DEFAULT="(.*)"$'
+    line: 'GRUB_CMDLINE_LINUX_DEFAULT="\1 rootflags=usrquota,grpquota"'
+    backup: true
+    backrefs: true
+  when:
+    - mode == "post"
+    - ansible_os_family == 'RedHat'
+    - ansible_distribution_major_version == '9'
+
+- name: Regenerate grub config
+  command: /sbin/grub2-mkconfig --update-bls-cmdline -o /boot/grub2/grub.cfg
+  when:
+    - mode == "post"
+    - ansible_os_family == 'RedHat'
+    - ansible_distribution_major_version == '9'
+
+- name: Ensure quota flags on root partition
+  mount:
+    path: /
+    state: mounted
+    fstype: xfs
+    src: {{ansible_cmdline.root}}
+    opts: defaults,noatime,usrquota,grpquota
+  when:
+    - mode == "post"
+    - ansible_os_family == 'RedHat'
+    - ansible_distribution_major_version == '9'
+
 ## this should always be the last task
 - name: Restart Cloudhost
   reboot:


### PR DESCRIPTION
see: https://liquidweb.atlassian.net/browse/ENG-3937

tested as follows:
```
$ ansible all -l 'cloudhost-13294694.us-midwest-1.nxcli.net' --become -m mount -a 'path=/ state=mounted fstype=xfs src={{ ansible_cmdline.root }} opts=defaults,noatime,usrquota,grpquota'
cloudhost-13294694.us-midwest-1.nxcli.net | CHANGED => {
    "backup_file": "",
    "boot": "yes",
    "changed": true,
    "dump": "0",
    "fstab": "/etc/fstab",
    "fstype": "xfs",
    "name": "/",
    "opts": "defaults,noatime,usrquota,grpquota",
    "passno": "0",
    "src": "UUID=8b81c9e7-5c4e-465e-994a-0c461380b4b6"
}
```

and the resulting fstab entry:
```
[1632][root@cloudhost-13294694 corlando]$ grep '8b81c9e7-5c4e-465e-994a-0c461380b4b6' /etc/fstab
UUID=8b81c9e7-5c4e-465e-994a-0c461380b4b6 / xfs defaults,noatime,usrquota,grpquota 0 0
```