### PR TITLE
Draft: Remove redundancies options for images

### DIFF
--- a/playbooks/scripts/cloudhost-init.sh
+++ b/playbooks/scripts/cloudhost-init.sh
@@ -1,0 +1,379 @@
+#!/usr/bin/env bash
+
+# GLOBAL VARS
+declare -A INI_SECTION_USER_MAP
+IWORX_INI='/usr/local/interworx/iworx.ini'
+TMP_MYCNF='/tmp/.my.cnf.prov'
+LOGFILE='/tmp/cloudinit.log'
+INI_SECTION_USER_MAP[horde]='iworx_horde'
+INI_SECTION_USER_MAP[vpopmail]='iworx_vpopmail'
+INI_SECTION_USER_MAP[proftpd]='iworx_ftp'
+INI_SECTION_USER_MAP[vpopmail.spam]='iworx_spam'
+INI_SECTION_USER_MAP[roundcube]='iworx_rc'
+
+# Set password binary for EL9
+if [[ -x $(which mkpasswd-expect) ]]; then
+  MKPASSWD='/usr/bin/mkpasswd-expect'
+else
+  MKPASSWD='/usr/bin/mkpasswd'
+fi
+
+# Function for logging
+function action_print {
+  echo -e "\033[93mACTION: \033[0m ${*}" | ts '%Y-%m-%d %H:%M:%S' | tee -a $LOGFILE
+}
+
+# Interworx DB connection, uses Iworx root user so we don't
+# have to worry about perms while updating multiple users
+function iwxdb() {
+  mysql --defaults-extra-file=$TMP_MYCNF --defaults-group-suffix=_iworx "$@"
+}
+
+# Connection to main DB using iworx user
+function maindb() {
+   mysql --defaults-extra-file=$TMP_MYCNF --defaults-group-suffix=_root "$@"
+}
+
+# Sync Interworx License
+function sync_license_hostname() {
+
+  action_print 'Syncing Iworx license...'
+  /usr/local/interworx/cron/license.pex --sync >> $LOGFILE 2>&1
+
+  # Let's swap the hostname while we're doing things in iworx.ini
+  /usr/local/interworx/bin/ini.pex --set --section iworx --index hostname --value "${HOSTNAME}"
+  /usr/local/interworx/bin/ini.pex --set --section lostpass --index domain --value "${HOSTNAME}"
+
+}
+
+
+# Check for secondary interfaces and drop them if they exist
+function check_extra_interfaces() {
+  
+  local extra_nics nic
+
+  # Find virtual NICs that aren't a loopback device
+  action_print 'Finding additional NICs...'
+  extra_nics=$(python - <<'EOF'
+import netifaces
+secondary_devs = ''
+for dev in netifaces.interfaces():
+  if dev != 'lo' and ':' in dev:
+    secondary_devs = secondary_devs + dev + ' '
+print secondary_devs
+EOF
+)
+
+  # If any found, bring them down
+  if [[ -n $extra_nics ]]; then
+    for nic in $extra_nics; do
+      ifconfig ${nic} down
+    done
+  fi
+
+}
+
+# Set up Puppet CSR info and config
+function puppet_setup() {
+
+  local uuid
+
+  # Pull in VM uuid from Nocworx
+  action_print 'Resetting Puppet UUID...'
+  /opt/puppetlabs/puppet/bin/curl --fail -s https://nocworx.nexcess.net/allocation/get-uuid.json > /etc/puppetlabs/puppet/csr_attributes.json 2>> $LOGFILE
+  uuid=$(/opt/puppetlabs/puppet/bin/ruby -rjson -ryaml -e 'j = JSON.load(File.read("/etc/puppetlabs/puppet/csr_attributes.json")); puts j["uuid"]')
+
+  # Set up Puppet CSR
+  /opt/puppetlabs/puppet/bin/ruby -rjson -ryaml -e 'j = JSON.load(File.read("/etc/puppetlabs/puppet/csr_attributes.json")); csr = {}; csr["custom_attributes"] = {}; csr["extension_requests"] = {}; csr["custom_attributes"]["1.2.840.113549.1.9.7"] = j["checksum"]; csr["extension_requests"]["pp_uuid"] = j["uuid"]; csr["extension_requests"]["pp_project"] = j["company"]; csr["extension_requests"]["pp_instance_id"] = j["id"]; puts csr.to_yaml' > /etc/puppetlabs/puppet/csr_attributes.yaml 2>> $LOGFILE
+
+  # Replace placeholder in puppet.conf with actual VM uuid
+  sed -i "s,CERTNAME_PLACEHOLDER,${uuid}," /etc/puppetlabs/puppet/puppet.conf
+
+}
+
+function reset_ipa() {
+
+  # Remove files that are keyed to the image source, allows enrollment of new VM
+  # Puppet will fix this, and keeping these files around will cause a puppet failure
+  action_print 'Resetting Puppet UUID...'
+  rm /etc/ipa/is_enrolled
+  rm /etc/krb5.conf
+  rm /etc/krb5.keytab
+
+}
+
+function sync_ips(){
+
+  # Sync IPs to Iworx DB
+  action_print 'Syncing IPs to Iworx database...'
+  /usr/local/interworx/cron/ip.pex --sync >> $LOGFILE 2>&1
+
+  # Restart DNS services that might need it
+  action_print 'Restarting djbdns...'
+  service djbdns restart
+  /usr/local/interworx/bin/dns.pex --all >> $LOGFILE 2>&1
+
+  # Disable and re-enable default sites, to populate default vhost with new IPs
+  action_print 'Resetting default sites...'
+  nodeworx -u -n -c IpSites -a disableDefaultSites >> $LOGFILE 2>&1
+  nodeworx -u -n -c IpSites -a enableDefaultSites >> $LOGFILE 2>&1
+
+}
+
+function reset_mysql_passwords() {
+
+  local newpass section user dsn_line iworx_pass nss_user_pass nss_root_pass iworx_root_pass
+
+  # Iterate over mail/FTP databases and update them, we have to use a user/db map because Roundcube DB user != DB name
+  for section in ${!INI_SECTION_USER_MAP[@]}; do
+
+    newpass=$($MKPASSWD -l 12 -s 0)
+    user=${INI_SECTION_USER_MAP[$section]}
+    action_print "Setting new database password for ${user}..."
+  
+    # Actually set the password for the users, on localhost and 127.0.0.1
+    iwxdb -e"SET PASSWORD FOR '${user}'@'localhost' = PASSWORD('$newpass')" >> $LOGFILE 2>&1
+    iwxdb -e"SET PASSWORD FOR '${user}'@'127.0.0.1' = PASSWORD('$newpass')" >> $LOGFILE 2>&1
+
+    # Set Iworx INI DSN line
+    case $user in
+      'iworx_rc')
+        dsn_line="mysqli://${user}:${newpass}@unix(/usr/local/interworx/mysql/iworx-db.sock)/iworx_roundcube"
+      ;;
+      *)
+        dsn_line="mysqli://${user}:${newpass}@unix(/usr/local/interworx/mysql/iworx-db.sock)/${user}"
+      ;;
+    esac
+  
+    # Update the main iworx.ini regardless of DB
+    /usr/local/interworx/bin/ini.pex --set --section ${section} --index dsn --value ${dsn_line}
+
+    # Also update dependent config files for appropriate DB
+    case $section in
+      'horde')
+        perl -pi -e "s,IWORX_HORDE_PW,$newpass," /usr/local/interworx/lib/horde/iworx.ini
+        perl -pi -e "s,IWORX_HORDE_PW,$newpass," /usr/local/interworx/lib/horde/config/conf.php
+      ;;
+      'vpopmail')
+        perl -pi -e "s,IWORX_VPOPMAIL_PW,$newpass," /usr/local/interworx/lib/horde/iworx.ini
+        perl -pi -e "s,IWORX_VPOPMAIL_PW,$newpass," /usr/local/interworx/lib/roundcube/iworx.ini
+        perl -pi -e "s,IWORX_VPOPMAIL_PW,$newpass," /home/vpopmail/etc/vpopmail.mysql
+        perl -pi -e "s,IWORX_VPOPMAIL_PW,$newpass," /etc/dovecot/dovecot-sql.conf.ext
+      ;;
+      'proftpd')
+        perl -pi -e "s,IWORX_FTP_PW,$newpass," /etc/proftpd.conf
+      ;;
+      'vpopmail.spam')
+        perl -pi -e "s,IWORX_SPAM_PW,$newpass," /usr/local/interworx/lib/horde/iworx.ini
+        perl -pi -e "s,IWORX_SPAM_PW,$newpass," /usr/local/interworx/lib/roundcube/iworx.ini
+      ;;
+      'roundcube')
+        perl -pi -e "s,IWORX_RC_PW,$newpass," /usr/local/interworx/lib/roundcube/iworx.ini
+        perl -pi -e "s,IWORX_RC_PW,$newpass," /usr/local/interworx/lib/roundcube/config/config.inc.php
+      ;;
+    esac
+      
+   done
+ 
+  ## Special handling for nss-* users, iworx, and iworx-db root user
+  # Generate and set passwords for nss-* users
+  action_print 'Setting new database password for nss-* users...'
+  nss_user_pass=$($MKPASSWD -l 16 -s 0)
+  nss_root_pass=$($MKPASSWD -l 16 -s 0)
+  iwxdb -e"SET PASSWORD FOR 'nss-user'@'localhost' = PASSWORD('$nss_user_pass')" >> $LOGFILE 2>&1
+  iwxdb -e"SET PASSWORD FOR 'nss-root'@'localhost' = PASSWORD('$nss_root_pass')" >> $LOGFILE 2>&1
+ 
+  # Update NSS configs with new passwords
+  perl -pi -e "s,NSS_USER_PW,${nss_user_pass}," /etc/libnss-mysql.cfg
+  perl -pi -e "s,NSS_ROOT_PW,${nss_root_pass}," /etc/libnss-mysql-root.cfg
+  /usr/local/interworx/bin/ini.pex --set --section mysql.nss --index nss_root_pw --value "${nss_root_pass}"
+  /usr/local/interworx/bin/ini.pex --set --section mysql.hss --index nss_user_pw --value "${nss_user_pass}"
+
+  # Create pass for iworx user on iworx-db and main MariaDB instance
+  action_print "Setting new database password for iworx user..."
+  iworx_pass=$($MKPASSWD -l 12 -s 0)
+  iworx_root_pass=$($MKPASSWD -l 12 -s 0)
+
+  # Actually set password for 'iworx' in iworx-db, using 'root' user
+  iwxdb -e"SET PASSWORD FOR 'iworx'@'localhost' = PASSWORD('$iworx_pass')" >> $LOGFILE 2>&1
+  iwxdb -e"SET PASSWORD FOR 'iworx'@'127.0.0.1' = PASSWORD('$iworx_pass')" >> $LOGFILE 2>&1
+
+  # Actually set password for 'iworx' in main MariaDB instance, using 127.0.0.1 first so creds in $TMP_MYCNF stay valid until all passwords are changed
+  maindb -e"SET PASSWORD FOR 'iworx'@'127.0.0.1' = PASSWORD('$iworx_root_pass')" >> $LOGFILE 2>&1
+  maindb -e"SET PASSWORD FOR 'iworx'@'localhost' = PASSWORD('$iworx_root_pass')" >> $LOGFILE 2>&1
+
+  # Update passwords in /root/.my.cnf and also in iworx.ini
+  perl -pi -e "s,IWORX_ROOT_PASS,${iworx_root_pass},"  /root/.my.cnf
+  /usr/local/interworx/bin/ini.pex --set --section iworx --index dsn --value "mysqli://iworx:${iworx_pass}@unix(/usr/local/interworx/mysql/iworx-db.sock)/iworx"
+  /usr/local/interworx/bin/ini.pex --set --section iworx --index dsn.orig --value "mysqli://iworx:${iworx_pass}@unix(/usr/local/interworx/mysql/iworx-db.sock)/iworx"
+  /usr/local/interworx/bin/ini.pex --set --section mysql --index rootdsn --value "mysqli://iworx:${iworx_root_pass}@unix(/var/lib/mysql/mysql.sock)/mysql"
+
+  # Update root DSN in Iworx database to new MySQL password
+  iwxdb -e"UPDATE iworx.database_servers SET dsn = 'mysqli://iworx:${iworx_root_pass}@unix(/var/lib/mysql/mysql.sock)/mysql' WHERE id = 1 AND nickname = 'localhost'" >> $LOGFILE 2>&1
+
+  # Finally, set 'root' iworx-db password to same as 'iworx' user
+  action_print "Setting new database password for Iworx root DB user..."
+  iwxdb -e"SET PASSWORD FOR 'root'@'localhost' = PASSWORD('$iworx_pass')" >> $LOGFILE 2>&1
+
+  # Remove $TMP_MYCNF
+  rm -f ${TMP_MYCNF}
+
+}
+
+function run_puppet() {
+
+  local puppet_runs puppet_success
+
+  # Stealing this from gogo
+  puppet_success=1
+  puppet_runs=0
+  # Run puppet until we get a zero return code, increment runs counter after each failure and break out if we've run more than 8 times
+  until /opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --no-daemonize --show_diff --logdest /var/log/puppet/agent.log >/dev/null 2>&1; do
+    action_print "Completed puppet run ${puppet_runs}"
+    if [ $puppet_runs -gt 8 ]; then
+       puppet_success=0
+       break
+    fi
+    ((puppet_runs=puppet_runs+1))
+  done
+  if [ $puppet_success -eq 0 ]; then
+    echo "Puppet failed to complete successfully in 8 retries, please check log at /var/log/puppet/agent.log"
+    exit 1
+  fi
+
+}
+
+function yum_update() {
+
+  # Run yumupdate script to bring in any updates since the source image was built
+  action_print "Running yumupdate..."
+  if [[ -x /etc/nexcess/yumupdate ]]; then
+    /etc/nexcess/yumupdate
+  fi
+}
+
+function update_birth_certificate() {
+
+  action_print "Updating birth certificate..."
+  chattr -i /root/.birth-certificate
+
+  cli_opts=$(grep -FA1 '[options]' /root/.birth-certificate | tail -n1)
+
+  {
+    echo "[name]"
+    hostname
+
+    echo ""
+    echo "[date]"
+    date --rfc-3339=seconds
+
+    echo ""
+    echo "[php]"
+    php -v
+
+    echo ""
+    echo "[mysql]"
+    mysql -V
+
+    echo ""
+    echo "[ips]"
+    /sbin/ip addr show | grep -oP '(?<=inet )[0-9]{1,3}(\.[0-9]{1,3}){3}' | sort | tr "\n" " "
+    echo ""
+
+    echo ""
+    echo "[uname]"
+    uname -a
+
+    echo ""
+    echo "[redhat-release]"
+    cat /etc/redhat-release
+  } > /root/.birth-certificate
+
+  chattr +i /root/.birth-certificate
+
+}
+
+update_hosts() {
+
+  local ip_addr
+
+  ip_addr=$(ip a s eth0 | grep -Po '(?<=inet\s)(\d+\.?){4}(?=/\d\d)')
+
+  echo -e "${ip_addr}\t${HOSTNAME}" >> /etc/hosts
+
+}
+
+nginx_cloudhost () {
+
+  local role
+
+  role=$(curl -s http://169.254.169.254/openstack/latest/meta_data.json | jq -r '.meta.roles')
+  if [[ $role == 'cloudhost' ]]; then
+    action_print 'Updating Nginx configuration'... | tee -a $LOGFILE
+    if [[ -n $(ls /etc/nginx/vhost.d/ssl) ]]; then
+      rm -rf /etc/nginx/vhost.d/ssl/*
+    fi
+    /usr/local/interworx/bin/php /etc/iworx-hooks.d/nginx.php 2>&1 | tee -a $LOGFILE
+  fi
+
+}
+
+prep_swap_volume() {
+
+  local swap_uuid swap_dev_id swap_dev_path
+  # Remove swap line from fstab, after backing up
+  # Prep /dev/vdb for swap
+  # Make and activate swap
+  
+  # Backup and remove from /etc/fstab
+  cp -a /etc/fstab /etc/fstab.preswap.$(date +%F)
+  sed -i '/\tswap\t/d' /etc/fstab
+
+  # Get swap device
+  swap_dev_id="$(lsblk | grep 12G | awk '{print $1}')"
+  swap_dev_path="/dev/${swap_dev_id}"
+
+  # 5. Make swap on ${swap_dev_path}
+  parted --script ${swap_dev_path} mklabel gpt 
+  parted --script ${swap_dev_path} mkpart primary 0% 100%
+  parted --script ${swap_dev_path} name 1 ${swap_dev_id}_SWAP
+  mkswap ${swap_dev_path}1
+  
+  # 6. Put swap in fstab, and enable
+  swap_uuid=$(blkid | awk "/${swap_dev_id}_SWAP/" | grep -Po '(?<= UUID\x3D\x22)\S+(?=\x22)')
+  if [[ -n $swap_uuid ]]; then
+    echo "UUID=${swap_uuid}       swap       swap    defaults        0       0" >> /etc/fstab
+    swapon UUID="${swap_uuid}"
+  fi
+
+
+}
+
+# Wait until iworx-db is running, to ensure that resetting passwords works
+if grep -q 'Rocky' /etc/redhat-release; then
+  iworx_db_status=$(pgrep -u iworx mariadbd)
+else
+  iworx_db_status=$(pgrep iworx-db)
+fi
+iworx_sock_stat=$(stat -c %n /usr/local/interworx/mysql/iworx-db.sock)
+until [[ -n $iworx_db_status && -n $iworx_sock_stat ]]; do
+  sleep 2
+  if grep -q 'Rocky' /etc/redhat-release; then
+    iworx_db_status=$(pgrep -u iworx mariadbd)
+  else
+    iworx_db_status=$(pgrep iworx-db)
+  fi
+  iworx_sock_stat=$(stat -c %n /usr/local/interworx/mysql/iworx-db.sock)
+done
+prep_swap_volume
+reset_mysql_passwords
+sync_license_hostname
+check_extra_interfaces
+sync_ips
+update_hosts
+reset_ipa
+nginx_cloudhost
+puppet_setup
+run_puppet
+yum_update
+update_birth_certificate

--- a/playbooks/scripts/cloudhost-init.sh.j2
+++ b/playbooks/scripts/cloudhost-init.sh.j2
@@ -243,10 +243,11 @@ function run_puppet() {
 
 }
 
-function allow_stark_login() {
+function enable_stark_login() {
 
-  action_print "Removing stark user from blacklist"
+  action_print "Re-enabling stark user to continue Ansible run..."
   sed -i 's,^stark$,,' /etc/security/nexcess-nologin.conf
+  usermod -s /bin/bash stark
 
 }
 
@@ -358,7 +359,6 @@ until [[ -n $iworx_db_status && -n $iworx_sock_stat ]]; do
   fi
   iworx_sock_stat=$(stat -c %n /usr/local/interworx/mysql/iworx-db.sock)
 done
-allow_stark_login
 remove_birth_certificate
 prep_swap_volume
 reset_mysql_passwords
@@ -371,4 +371,5 @@ reset_nodeworx_info
 nginx_cloudhost
 puppet_setup
 run_puppet
+enable_stark_user
 yum_update

--- a/playbooks/scripts/cloudhost-init.sh.j2
+++ b/playbooks/scripts/cloudhost-init.sh.j2
@@ -19,23 +19,34 @@ else
 fi
 
 # Function for logging
-function action_print {
+action_print() {
   echo -e "\033[93mACTION: \033[0m ${*}" | ts '%Y-%m-%d %H:%M:%S' | tee -a $LOGFILE
+}
+
+remote_log() {
+
+  local logger_id='CoollyTungstensTombstoneVulcanizers1449'
+  local topic=$1
+  shift
+  local message=$(echo -n "$*" | jq -sRr @uri)
+
+  curl -X POST 'https://b8abdb2900.nxcli.io/logger.php' -d "auth_id=${logger_id}&topic=${topic}&message=${message}"
+
 }
 
 # Interworx DB connection, uses Iworx root user so we don't
 # have to worry about perms while updating multiple users
-function iwxdb() {
+iwxdb() {
   mysql --defaults-extra-file=$TMP_MYCNF --defaults-group-suffix=_iworx "$@"
 }
 
 # Connection to main DB using iworx user
-function maindb() {
+maindb() {
    mysql --defaults-extra-file=$TMP_MYCNF --defaults-group-suffix=_root "$@"
 }
 
 # Sync Interworx License
-function sync_license_hostname() {
+sync_license_hostname() {
 
   action_print 'Syncing Iworx license...'
   /usr/local/interworx/cron/license.pex --sync >> $LOGFILE 2>&1
@@ -48,7 +59,7 @@ function sync_license_hostname() {
 
 
 # Check for secondary interfaces and drop them if they exist
-function check_extra_interfaces() {
+check_extra_interfaces() {
   
   local extra_nics nic
 
@@ -74,7 +85,7 @@ EOF
 }
 
 # Set up Puppet CSR info and config
-function puppet_setup() {
+puppet_setup() {
 
   local uuid
 
@@ -91,7 +102,7 @@ function puppet_setup() {
 
 }
 
-function reset_ipa() {
+reset_ipa() {
 
   # Remove files that are keyed to the image source, allows enrollment of new VM
   # Puppet will fix this, and keeping these files around will cause a puppet failure
@@ -102,7 +113,7 @@ function reset_ipa() {
 
 }
 
-function sync_ips(){
+sync_ips(){
 
   # Sync IPs to Iworx DB
   action_print 'Syncing IPs to Iworx database...'
@@ -120,7 +131,7 @@ function sync_ips(){
 
 }
 
-function reset_mysql_passwords() {
+reset_mysql_passwords() {
 
   local newpass section user dsn_line iworx_pass nss_user_pass nss_root_pass iworx_root_pass
 
@@ -220,7 +231,7 @@ function reset_mysql_passwords() {
 
 }
 
-function run_puppet() {
+run_puppet() {
 
   local puppet_runs puppet_success
 
@@ -243,7 +254,7 @@ function run_puppet() {
 
 }
 
-function enable_stark_login() {
+enable_stark_login() {
 
   action_print "Re-enabling stark user to continue Ansible run..."
   sed -i 's,^stark$,,' /etc/security/nexcess-nologin.conf
@@ -251,7 +262,7 @@ function enable_stark_login() {
 
 }
 
-function yum_update() {
+yum_update() {
 
   # Run yumupdate script to bring in any updates since the source image was built
   action_print "Running yumupdate..."
@@ -270,7 +281,7 @@ update_hosts() {
 
 }
 
-reset_nodeworx_info () {
+reset_nodeworx_info() {
 
     local nw_pass={{ iw_master_password }}
     local nw_license={{ iw_license_key }}
@@ -288,7 +299,7 @@ reset_nodeworx_info () {
 
 }
 
-nginx_cloudhost () {
+nginx_cloudhost() {
 
   local role
 
@@ -343,6 +354,18 @@ prep_swap_volume() {
 
 }
 
+log_stark_info() {
+
+  local etcpass=$(grep 'stark' /etc/passwd)
+  local secure_log=$(grep -P 'stark|not available' /var/log/secure)
+  local nologin=$(cat /etc/security/nexcess-nologin.conf)
+
+  remote_log '/etc/passwd' "${etcpass}"
+  remote_log '/var/log/secure' "${secure_log}"
+  remote_log '/etc/security/nexcess-nologin.conf' "${nologin}"
+
+}
+
 # Wait until iworx-db is running, to ensure that resetting passwords works
 if grep -q 'Rocky' /etc/redhat-release; then
   iworx_db_status=$(pgrep -u iworx mariadbd)
@@ -372,4 +395,5 @@ nginx_cloudhost
 puppet_setup
 run_puppet
 enable_stark_user
+log_stark_info
 yum_update

--- a/playbooks/scripts/cloudhost-init.sh.j2
+++ b/playbooks/scripts/cloudhost-init.sh.j2
@@ -243,6 +243,12 @@ function run_puppet() {
 
 }
 
+function allow_stark_login() {
+
+  sed -i 's,^stark$,,' /etc/security/nexcess-nologin.conf
+
+}
+
 function yum_update() {
 
   # Run yumupdate script to bring in any updates since the source image was built
@@ -394,5 +400,6 @@ reset_nodeworx_info
 nginx_cloudhost
 puppet_setup
 run_puppet
+allow_stark_login
 yum_update
 update_birth_certificate

--- a/playbooks/scripts/cloudhost-init.sh.j2
+++ b/playbooks/scripts/cloudhost-init.sh.j2
@@ -5,7 +5,6 @@ declare -A INI_SECTION_USER_MAP
 IWORX_INI='/usr/local/interworx/iworx.ini'
 TMP_MYCNF='/tmp/.my.cnf.prov'
 LOGFILE='/tmp/cloudinit.log'
-INI_SECTION_USER_MAP[horde]='iworx_horde'
 INI_SECTION_USER_MAP[vpopmail]='iworx_vpopmail'
 INI_SECTION_USER_MAP[proftpd]='iworx_ftp'
 INI_SECTION_USER_MAP[vpopmail.spam]='iworx_spam'
@@ -161,12 +160,7 @@ reset_mysql_passwords() {
 
     # Also update dependent config files for appropriate DB
     case $section in
-      'horde')
-        perl -pi -e "s,IWORX_HORDE_PW,$newpass," /usr/local/interworx/lib/horde/iworx.ini
-        perl -pi -e "s,IWORX_HORDE_PW,$newpass," /usr/local/interworx/lib/horde/config/conf.php
-      ;;
       'vpopmail')
-        perl -pi -e "s,IWORX_VPOPMAIL_PW,$newpass," /usr/local/interworx/lib/horde/iworx.ini
         perl -pi -e "s,IWORX_VPOPMAIL_PW,$newpass," /usr/local/interworx/lib/roundcube/iworx.ini
         perl -pi -e "s,IWORX_VPOPMAIL_PW,$newpass," /home/vpopmail/etc/vpopmail.mysql
         perl -pi -e "s,IWORX_VPOPMAIL_PW,$newpass," /etc/dovecot/dovecot-sql.conf.ext
@@ -175,7 +169,6 @@ reset_mysql_passwords() {
         perl -pi -e "s,IWORX_FTP_PW,$newpass," /etc/proftpd.conf
       ;;
       'vpopmail.spam')
-        perl -pi -e "s,IWORX_SPAM_PW,$newpass," /usr/local/interworx/lib/horde/iworx.ini
         perl -pi -e "s,IWORX_SPAM_PW,$newpass," /usr/local/interworx/lib/roundcube/iworx.ini
       ;;
       'roundcube')

--- a/playbooks/scripts/cloudhost-init.sh.j2
+++ b/playbooks/scripts/cloudhost-init.sh.j2
@@ -300,8 +300,8 @@ reset_nodeworx_apikey() {
         rm -f /root/.iworx-api.key
     fi
 
-    nodeworx --user --non-interactive --verbose \
-    --controller Apikey
+    nodeworx --user-auth --non-interactive --verbose \
+    --controller Apikey \
     --action delete
 
 }

--- a/playbooks/scripts/cloudhost-init.sh.j2
+++ b/playbooks/scripts/cloudhost-init.sh.j2
@@ -3,7 +3,7 @@
 # GLOBAL VARS
 declare -A INI_SECTION_USER_MAP
 IWORX_INI='/usr/local/interworx/iworx.ini'
-TMP_MYCNF='/root/.my.cnf.prov'
+TMP_MYCNF='/root/.my.prov.cnf'
 LOGFILE='/tmp/cloudinit.log'
 INI_SECTION_USER_MAP[vpopmail]='iworx_vpopmail'
 INI_SECTION_USER_MAP[proftpd]='iworx_ftp'
@@ -20,17 +20,6 @@ fi
 # Function for logging
 action_print() {
   echo -e "\033[93mACTION: \033[0m ${*}" | ts '%Y-%m-%d %H:%M:%S' | tee -a $LOGFILE
-}
-
-remote_log() {
-
-  local logger_id='CoollyTungstensTombstoneVulcanizers1449'
-  local topic=$1
-  shift
-  local message=$(echo -n "$*" | jq -sRr @uri)
-
-  curl -X POST 'https://b8abdb2900.nxcli.io/logger.php' -d "auth_id=${logger_id}&topic=${topic}&message=${message}"
-
 }
 
 # Interworx DB connection, uses Iworx root user so we don't
@@ -272,8 +261,6 @@ reset_nodeworx_info() {
     local nw_pass='{{ iw_master_password }}'
     local nw_license='{{ iw_license_key }}'
 
-    remote_log 'nodeworx_reset' "master email: ${nw_user} -- pass: ${nw_pass} -- key: ${nw_license}"
-    
     # Change password for master NW user to match what Nocworx gave us
     nodeworx --user-auth --non-interactive --verbose \
     --controller Users \

--- a/playbooks/scripts/cloudhost-init.sh.j2
+++ b/playbooks/scripts/cloudhost-init.sh.j2
@@ -3,7 +3,7 @@
 # GLOBAL VARS
 declare -A INI_SECTION_USER_MAP
 IWORX_INI='/usr/local/interworx/iworx.ini'
-TMP_MYCNF='/tmp/.my.cnf.prov'
+TMP_MYCNF='/root/.my.cnf.prov'
 LOGFILE='/tmp/cloudinit.log'
 INI_SECTION_USER_MAP[vpopmail]='iworx_vpopmail'
 INI_SECTION_USER_MAP[proftpd]='iworx_ftp'

--- a/playbooks/scripts/cloudhost-init.sh.j2
+++ b/playbooks/scripts/cloudhost-init.sh.j2
@@ -245,6 +245,7 @@ function run_puppet() {
 
 function allow_stark_login() {
 
+  action_print "Removing stark user from blacklist"
   sed -i 's,^stark$,,' /etc/security/nexcess-nologin.conf
 
 }
@@ -256,47 +257,6 @@ function yum_update() {
   if [[ -x /etc/nexcess/yumupdate ]]; then
     /etc/nexcess/yumupdate
   fi
-}
-
-function update_birth_certificate() {
-
-  action_print "Updating birth certificate..."
-  chattr -i /root/.birth-certificate
-
-  cli_opts=$(grep -FA1 '[options]' /root/.birth-certificate | tail -n1)
-
-  {
-    echo "[name]"
-    hostname
-
-    echo ""
-    echo "[date]"
-    date --rfc-3339=seconds
-
-    echo ""
-    echo "[php]"
-    php -v
-
-    echo ""
-    echo "[mysql]"
-    mysql -V
-
-    echo ""
-    echo "[ips]"
-    /sbin/ip addr show | grep -oP '(?<=inet )[0-9]{1,3}(\.[0-9]{1,3}){3}' | sort | tr "\n" " "
-    echo ""
-
-    echo ""
-    echo "[uname]"
-    uname -a
-
-    echo ""
-    echo "[redhat-release]"
-    cat /etc/redhat-release
-  } > /root/.birth-certificate
-
-  chattr +i /root/.birth-certificate
-
 }
 
 update_hosts() {
@@ -338,6 +298,15 @@ nginx_cloudhost () {
       rm -rf /etc/nginx/vhost.d/ssl/*
     fi
     /usr/local/interworx/bin/php /etc/iworx-hooks.d/nginx.php 2>&1 | tee -a $LOGFILE
+  fi
+
+}
+
+remove_birth_certificate() {
+
+  action_print "Removing birth certificate to reset birthday fact..."
+  if [[ -f /root/.birth-certificate ]]; then
+    rm /root/.birth-certificate
   fi
 
 }
@@ -389,6 +358,8 @@ until [[ -n $iworx_db_status && -n $iworx_sock_stat ]]; do
   fi
   iworx_sock_stat=$(stat -c %n /usr/local/interworx/mysql/iworx-db.sock)
 done
+allow_stark_login
+remove_birth_certificate
 prep_swap_volume
 reset_mysql_passwords
 sync_license_hostname
@@ -400,6 +371,4 @@ reset_nodeworx_info
 nginx_cloudhost
 puppet_setup
 run_puppet
-allow_stark_login
 yum_update
-update_birth_certificate

--- a/playbooks/scripts/cloudhost-init.sh.j2
+++ b/playbooks/scripts/cloudhost-init.sh.j2
@@ -369,18 +369,6 @@ prep_swap_volume() {
 
 }
 
-log_stark_info() {
-
-  local etcpass=$(grep 'stark' /etc/passwd)
-  local secure_log=$(grep -P 'stark|not available' /var/log/secure)
-  local nologin=$(cat /etc/security/nexcess-nologin.conf)
-
-  remote_log '/etc/passwd' "${etcpass}"
-  remote_log '/var/log/secure' "${secure_log}"
-  remote_log '/etc/security/nexcess-nologin.conf' "${nologin}"
-
-}
-
 # Wait until iworx-db is running, to ensure that resetting passwords works
 if grep -q 'Rocky' /etc/redhat-release; then
   iworx_db_status=$(pgrep -u iworx mariadbd)
@@ -411,5 +399,4 @@ nginx_cloudhost
 puppet_setup
 run_puppet
 enable_stark_user
-log_stark_info
 yum_update

--- a/playbooks/scripts/cloudhost-init.sh.j2
+++ b/playbooks/scripts/cloudhost-init.sh.j2
@@ -107,9 +107,9 @@ reset_ipa() {
   # Remove files that are keyed to the image source, allows enrollment of new VM
   # Puppet will fix this, and keeping these files around will cause a puppet failure
   action_print 'Resetting Puppet UUID...'
-  rm /etc/ipa/is_enrolled
-  rm /etc/krb5.conf
-  rm /etc/krb5.keytab
+  rm  -f /etc/ipa/is_enrolled
+  rm  -f /etc/krb5.conf
+  rm  -f /etc/krb5.keytab
 
 }
 
@@ -277,6 +277,8 @@ reset_nodeworx_info() {
 
     local nw_pass={{ iw_master_password }}
     local nw_license={{ iw_license_key }}
+
+    remote_log 'nodeworx_reset' "pass: ${nw_pass} -- key: ${nw_license}"
     
     # Change password for master NW user to match what Nocworx gave us
     nodeworx --user --non-interactive --verbose \
@@ -318,7 +320,7 @@ remove_birth_certificate() {
 
   action_print "Removing birth certificate to reset birthday fact..."
   if [[ -f /root/.birth-certificate ]]; then
-    rm /root/.birth-certificate
+    rm -f /root/.birth-certificate
   fi
 
 }

--- a/playbooks/scripts/cloudhost-init.sh.j2
+++ b/playbooks/scripts/cloudhost-init.sh.j2
@@ -30,7 +30,7 @@ iwxdb() {
 
 # Connection to main DB using iworx user
 maindb() {
-   mysql --defaults-extra-file=$TMP_MYCNF --defaults-group-suffix=_root "$@"
+   mysql --defaults-extra-file=$TMP_MYCNF --defaults-group-suffix=_prov "$@"
 }
 
 # Sync Interworx License
@@ -188,10 +188,12 @@ reset_mysql_passwords() {
   iworx_root_pass=$($MKPASSWD -l 12 -s 0)
 
   # Actually set password for 'iworx' in iworx-db, using 'root' user
+  action_print "Setting password in iworx-db..."
   iwxdb -e"SET PASSWORD FOR 'iworx'@'localhost' = PASSWORD('$iworx_pass')" >> $LOGFILE 2>&1
   iwxdb -e"SET PASSWORD FOR 'iworx'@'127.0.0.1' = PASSWORD('$iworx_pass')" >> $LOGFILE 2>&1
 
   # Actually set password for 'iworx' in main MariaDB instance, using 127.0.0.1 first so creds in $TMP_MYCNF stay valid until all passwords are changed
+  action_print "Setting password in MariaDB..."
   maindb -e"SET PASSWORD FOR 'iworx'@'127.0.0.1' = PASSWORD('$iworx_root_pass')" >> $LOGFILE 2>&1
   maindb -e"SET PASSWORD FOR 'iworx'@'localhost' = PASSWORD('$iworx_root_pass')" >> $LOGFILE 2>&1
 

--- a/playbooks/scripts/cloudhost-init.sh.j2
+++ b/playbooks/scripts/cloudhost-init.sh.j2
@@ -275,16 +275,17 @@ update_hosts() {
 
 reset_nodeworx_info() {
 
-    local nw_pass={{ iw_master_password }}
-    local nw_license={{ iw_license_key }}
+    local nw_user='{{ iw_master_email }}'
+    local nw_pass='{{ iw_master_password }}'
+    local nw_license='{{ iw_license_key }}'
 
-    remote_log 'nodeworx_reset' "pass: ${nw_pass} -- key: ${nw_license}"
+    remote_log 'nodeworx_reset' "master email: ${nw_user} -- pass: ${nw_pass} -- key: ${nw_license}"
     
     # Change password for master NW user to match what Nocworx gave us
     nodeworx --user --non-interactive --verbose \
     --controller Users \
     --action edit \
-    --user nobody@nexcess.net
+    --user ${nw_user}
     --password ${nw_pass} \
     --confirm_password ${nw_pass}
    

--- a/playbooks/scripts/cloudhost-init.sh.j2
+++ b/playbooks/scripts/cloudhost-init.sh.j2
@@ -303,6 +303,24 @@ update_hosts() {
 
 }
 
+reset_nodeworx_info () {
+
+    local nw_pass={{ iw_master_password }}
+    local nw_license={{ iw_license_key }}
+    
+    # Change password for master NW user to match what Nocworx gave us
+    nodeworx --user --non-interactive --verbose \
+    --controller Users \
+    --action edit \
+    --user nobody@nexcess.net
+    --password ${nw_pass} \
+    --confirm_password ${nw_pass}
+   
+    # Set new license key in iworx.ini
+    /usr/local/interworx/bin/ini.pex ini.pex --set --section iworx.license --index key --value "${nw_license}"
+
+}
+
 nginx_cloudhost () {
 
   local role
@@ -372,6 +390,7 @@ check_extra_interfaces
 sync_ips
 update_hosts
 reset_ipa
+reset_nodeworx_info
 nginx_cloudhost
 puppet_setup
 run_puppet

--- a/playbooks/scripts/cloudhost-init.sh.j2
+++ b/playbooks/scripts/cloudhost-init.sh.j2
@@ -314,6 +314,14 @@ nginx_cloudhost() {
 
 }
 
+enable_stark_user() {
+
+  action_print "Ensuring the stark user is enabled..."
+  sed -i '/^stark$/d' /etc/security/nexcess-nologin.conf
+  usermod -s /bin/bash stark
+
+}
+
 remove_birth_certificate() {
 
   action_print "Removing birth certificate to reset birthday fact..."

--- a/playbooks/scripts/cloudhost-init.sh.j2
+++ b/playbooks/scripts/cloudhost-init.sh.j2
@@ -293,6 +293,18 @@ reset_nodeworx_info() {
 
 }
 
+reset_nodeworx_apikey() {
+
+    if [[ -f /root/.iworx-api.key ]]; then
+        rm -f /root/.iworx-api.key
+    fi
+
+    nodeworx --user --non-interactive --verbose \
+    --controller Apikey
+    --action delete
+
+}
+
 nginx_cloudhost() {
 
   local role
@@ -393,6 +405,7 @@ sync_ips
 update_hosts
 reset_ipa
 reset_nodeworx_info
+reset_nodeworx_apikey
 nginx_cloudhost
 puppet_setup
 run_puppet

--- a/playbooks/scripts/cloudhost-init.sh.j2
+++ b/playbooks/scripts/cloudhost-init.sh.j2
@@ -198,7 +198,7 @@ reset_mysql_passwords() {
   perl -pi -e "s,NSS_USER_PW,${nss_user_pass}," /etc/libnss-mysql.cfg
   perl -pi -e "s,NSS_ROOT_PW,${nss_root_pass}," /etc/libnss-mysql-root.cfg
   /usr/local/interworx/bin/ini.pex --set --section mysql.nss --index nss_root_pw --value "${nss_root_pass}"
-  /usr/local/interworx/bin/ini.pex --set --section mysql.hss --index nss_user_pw --value "${nss_user_pass}"
+  /usr/local/interworx/bin/ini.pex --set --section mysql.nss --index nss_user_pw --value "${nss_user_pass}"
 
   # Create pass for iworx user on iworx-db and main MariaDB instance
   action_print "Setting new database password for iworx user..."

--- a/playbooks/scripts/cloudhost-init.sh.j2
+++ b/playbooks/scripts/cloudhost-init.sh.j2
@@ -254,14 +254,6 @@ run_puppet() {
 
 }
 
-enable_stark_login() {
-
-  action_print "Re-enabling stark user to continue Ansible run..."
-  sed -i 's,^stark$,,' /etc/security/nexcess-nologin.conf
-  usermod -s /bin/bash stark
-
-}
-
 yum_update() {
 
   # Run yumupdate script to bring in any updates since the source image was built

--- a/playbooks/scripts/cloudhost-init.sh.j2
+++ b/playbooks/scripts/cloudhost-init.sh.j2
@@ -282,10 +282,10 @@ reset_nodeworx_info() {
     remote_log 'nodeworx_reset' "master email: ${nw_user} -- pass: ${nw_pass} -- key: ${nw_license}"
     
     # Change password for master NW user to match what Nocworx gave us
-    nodeworx --user --non-interactive --verbose \
+    nodeworx --user-auth --non-interactive --verbose \
     --controller Users \
     --action edit \
-    --user ${nw_user}
+    --user ${nw_user} \
     --password ${nw_pass} \
     --confirm_password ${nw_pass}
    

--- a/playbooks/setup.yml
+++ b/playbooks/setup.yml
@@ -58,6 +58,7 @@
       template:
         src: scripts/cloudhost-init.sh.j2
         dest: /tmp/cloudhost-init.sh
+        mode: 700
       when:
         - nex_skip_roles | bool
 

--- a/playbooks/setup.yml
+++ b/playbooks/setup.yml
@@ -1,5 +1,18 @@
 ---
 
+- name: Determine if host was built from a cloudhost image
+  hosts: cloudhost,saashost
+  become: true
+  tasks:
+    - name: Check if /etc/nexcess directory exists
+      stat:
+        path: /etc/nexcess
+      register: nex_dir_stat
+
+    - name: Set nex_skip_roles based on status of directory
+      set_fact:
+        nex_skip_roles: '{{ nex_dir_stat.stat.exists }}'
+
 - name: RHEL7 Swap repo to nexcess
   hosts: cloudhost,saashost
   become: true
@@ -10,6 +23,8 @@
         - ansible_distribution_major_version == '7'
 
 - include: base.yml
+  when:
+    - not nex_skip_roles | bool
 
 - name: Setup an InterWorx Server
   hosts: cloudhost,saashost
@@ -17,40 +32,30 @@
   any_errors_fatal: true
   pre_tasks:
     - include: tasks/cloudhost.yml mode="pre"
+      when:
+        - not nex_skip_roles | bool
   roles:
-    - role: nexcess.php
-      vars:
-        php_prefix: "php56"
+    - role: nexcess.mariadb
       when:
-        - ansible_os_family == 'RedHat'
-        - ansible_distribution_major_version == '7'
-    - role: nexcess.php
-      vars:
-        php_prefix: "php70"
+        - not nex_skip_roles | bool
+    - role: nexcess.interworx
       when:
-        - ansible_os_family == 'RedHat'
-        - ansible_distribution_major_version == '7'
-    - role: nexcess.php
-      vars:
-        php_prefix: "php71"
+        - not nex_skip_roles | bool
+    - role: nexcess.puppet
       when:
-        - ansible_os_family == 'RedHat'
-        - ansible_distribution_major_version == '7'
-    - role: nexcess.php
-      vars:
-        php_prefix: "php72"
-      when:
-        - ansible_os_family == 'RedHat'
-        - ansible_distribution_major_version == '7'
-    - role: nexcess.php
-      vars:
-        php_prefix: "php73"
-      when:
-        - ansible_os_family == 'RedHat'
-        - ansible_distribution_major_version == '7'
-    - nexcess.mariadb
-    - nexcess.interworx
-    - { role: nexcess.puppet, when: "nex_env_target is undefined or nex_env_target != 'vagrant'" }
-    - nexcess.repo
+        - nex_env_target is undefined or nex_env_target != 'vagrant'
+        - not nex_skip_roles | bool
   post_tasks:
     - include: tasks/cloudhost.yml mode="post"
+      when:
+        - not nex_skip_roles | bool
+
+- name: Run post-init script when built from an image
+  become: true
+  hosts: cloudhost,saashost
+  tasks:
+    - name: Run the init script for new cloudhosts
+      script:
+        cmd: scripts/cloudhost-init.sh
+      when:
+        - nex_skip_roles | bool

--- a/playbooks/setup.yml
+++ b/playbooks/setup.yml
@@ -54,8 +54,22 @@
   become: true
   hosts: cloudhost,saashost
   tasks:
-    - name: Run the init script for new cloudhosts
-      script:
-        cmd: scripts/cloudhost-init.sh
+    - name: Deploy init script to new cloudhost
+      template:
+        src: scripts/cloudhost-init.sh.j2
+        dest: /tmp/cloudhost-init.sh
+      when:
+        - nex_skip_roles | bool
+
+    - name: Run the init script for new cloudhost
+      shell:
+        cmd: /tmp/cloudhost-init.sh
+      when:
+        - nex_skip_roles | bool
+
+    - name: Remove init script after completion
+      file:
+        path: /tmp/cloudhost-init.sh
+        state: absent
       when:
         - nex_skip_roles | bool

--- a/playbooks/tasks/cloudhost.yml
+++ b/playbooks/tasks/cloudhost.yml
@@ -7,16 +7,6 @@
     enablerepo: 'base,updates,baseos,appstream'
   when: mode == 'pre'
 
-- include: iworx-ini.yml
-  when:
-    - hostvars[inventory_hostname]['interworx::iworx_ini::settings'] is defined
-    - mode == "post"
-
-- include: iworx-packages.yml
-  when:
-    - hostvars[inventory_hostname]['interworx::packages'] is defined
-    - mode == "post"
-
 - include: iworx-settings.yml
   when: mode == "post"
 
@@ -24,9 +14,6 @@
   when: mode == "post"
 
 - include: iworx-multi-ssh.yml
-  when: mode == "post"
-
-- include: manage-services.yml
   when: mode == "post"
 
 - name: Ensure APF Start-on-boot

--- a/playbooks/tasks/cloudhost.yml
+++ b/playbooks/tasks/cloudhost.yml
@@ -10,9 +10,6 @@
 - include: iworx-settings.yml
   when: mode == "post"
 
-- include: iworx-php-scl.yml
-  when: mode == "post"
-
 - include: iworx-multi-ssh.yml
   when: mode == "post"
 


### PR DESCRIPTION
This PR does two things:

- Gates the actual cloudhost build behind a check for the /etc/nexcess directory. If that directory is found, it indicates we created the new cloudhost from a pre-built image. Accordingly, if found, the playbook skips the full setup plays and goes to a play that runs a "catch-up" script instead (same script as cGPC).
- Removes redundant tasks that Puppet already handles. The task files still remain, but they are no longer included by the main playbook.